### PR TITLE
Remove use of Darwin-only `ListFormatter`

### DIFF
--- a/Sources/ModifiedCopyMacros/ModifiedCopyMacro.swift
+++ b/Sources/ModifiedCopyMacros/ModifiedCopyMacro.swift
@@ -100,14 +100,11 @@ public struct ModifiedCopyCombiMacro: MemberMacro {
         
         let variablesCombi = variables.combinationsWithoutRepetition.filter { !$0.isEmpty }
         
-        let listFormatter = ListFormatter()
-        listFormatter.locale = .init(identifier: "en")
-        
         return variablesCombi.compactMap { variableCombi -> DeclSyntax? in
             let bindingsCombi = variableCombi.flatMap { $0.bindings }
             let many = bindingsCombi.count > 1
             
-            let propertyNamesString = listFormatter.string(from: bindingsCombi.map { "`\($0.pattern)`" }) ?? "?"
+            let propertyNamesString = bindingsCombi.map { "`\($0.pattern)`" }.joined(separator: " and ")
             let parameterListString = bindingsCombi.map { binding in "\(binding.pattern): \(binding.typeAnnotation?.type.trimmed ?? "?")" }.joined(separator: ", ")
             
             return """


### PR DESCRIPTION
Hi there! This change removes the use of `ListFormatter`, which is only available on Darwin platforms, meaning this macro can't be used in [Linux-hosted] [Vapor](https://vapor.codes) projects. With this small change, this project should compile on all Swift platforms.

It might be useful to add a simple GitHub Action to this project to build and test it on both platforms when changes are made to `main`. I've caught a number of small bugs / incompatibilities in my own projects that way. I'd be happy to open a separate PR to add the GitHub Action if you're interested. I'll paste the body of an action file from one of my projects below for reference, too.

<details>
<summary>Sample GHA file</summary>

```yaml
name: Build and Test

on:
  push:
    branches: [ main ]
  pull_request:
    branches: [ main ]

jobs:
  build-macos:
    name: "macOS"
    runs-on: macos-latest
    steps:
      - uses: maxim-lobanov/setup-xcode@v1
        with:
          xcode-version: 16.0
      - uses: actions/checkout@v4
      - name: Build and Run Tests
        run: swift test

  build-linux:
    name: "Linux"
    runs-on: ubuntu-latest

    steps:
      - uses: actions/checkout@v4
      - uses: SwiftyLab/setup-swift@latest
        with:
          swift-version: "6"
      - name: Build and Run Tests
        run: swift test
```
</details>