### PR TITLE
Update the location of the `swift-syntax` dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the latest Swift 5.9 prerelease of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.1.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.1.1"),
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
This is just a minor update that changes the location of the `swift-syntax` dependency to its new location. This doesn't yet produce errors, but I think it will soonish, and it _does_ produce warnings.

See https://www.swift.org/blog/swiftlang-github/