### PR TITLE
Add ModifiedCopy dependency to tests to allow testing from command line

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .testTarget(
             name: "ModifiedCopyTests",
             dependencies: [
+                "ModifiedCopy",
                 "ModifiedCopyMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ]


### PR DESCRIPTION
Add "ModifiedCopy" to test dependencies to allow testing from command line with "swift test".